### PR TITLE
Add requests_remaining and requests_per_day properties

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,8 +24,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pep517
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
+        if [ -f requirements-test.txt ]; then \
+          pip install -r requirements-test.txt; \
+        elif [ -f requirements.txt ]; then \
+          pip install -r requirements.txt; \
+        fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,6 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pep517
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/airly/__init__.py
+++ b/airly/__init__.py
@@ -48,3 +48,13 @@ class Airly:
         return MeasurementsSession(
             self._rh, MeasurementsSession.Mode.POINT,
             latitude=latitude, longitude=longitude)
+
+    @property
+    def requests_remaining(self):
+        """Returns the remaining number of requests."""
+        return self._rh.requests_remaining
+
+    @property
+    def requests_per_day(self):
+        """Returns the allowed number of requests per day."""
+        return self._rh.requests_per_day

--- a/airly/__init__.py
+++ b/airly/__init__.py
@@ -51,17 +51,20 @@ class Airly:
 
     @property
     def requests_remaining(self):
-        """Returns the remaining number of requests on a given day.
-        The counter is reset each day at midnight UTC.
+        """
+        Returns the remaining number of requests on a given day as Int or None if value
+        is unavailable. The counter is reset each day at midnight UTC.
         """
 
         return self._rh.requests_remaining
 
     @property
     def requests_per_day(self):
-        """Returns the allowed number of requests per day.
-        According to the API documentation, the default rate limit per API key
-        is 100 requests per day. But for old API keys (pre-2020), the rate
-        limit is 1000 requests per day.
+        """
+        Returns the allowed number of requests per day as Int or None if value is
+        unavailable.
+        According to the API documentation, the default rate limit per API key is 100
+        requests per day. But for old API keys (pre-2020), the rate limit is 1000
+        requests per day.
         """
         return self._rh.requests_per_day

--- a/airly/__init__.py
+++ b/airly/__init__.py
@@ -51,10 +51,17 @@ class Airly:
 
     @property
     def requests_remaining(self):
-        """Returns the remaining number of requests."""
+        """Returns the remaining number of requests on a given day.
+        The counter is reset each day at midnight UTC.
+        """
+
         return self._rh.requests_remaining
 
     @property
     def requests_per_day(self):
-        """Returns the allowed number of requests per day."""
+        """Returns the allowed number of requests per day.
+        According to the API documentation, the default rate limit per API key
+        is 100 requests per day. But for old API keys (pre-2020), the rate
+        limit is 1000 requests per day.
+        """
         return self._rh.requests_per_day

--- a/airly/_private.py
+++ b/airly/_private.py
@@ -34,6 +34,9 @@ class _RequestsHandler:
         url = self.base_url + request_path
         _LOGGER.debug("Sending request: " + url)
         async with self.session.get(url, headers=self.headers) as response:
+            # The values for the X-RateLimit-Limit-day and X-RateLimit-Remaining-day
+            # headers should be returned for HTTP status code 200 and 429, but sometimes
+            # they are missing for unknown reasons.
             if "X-RateLimit-Limit-day" in response.headers:
                 self.requests_per_day = response.headers["X-RateLimit-Limit-day"]
             if "X-RateLimit-Remaining-day" in response.headers:

--- a/airly/_private.py
+++ b/airly/_private.py
@@ -38,9 +38,9 @@ class _RequestsHandler:
             # headers should be returned for HTTP status code 200 and 429, but sometimes
             # they are missing for unknown reasons.
             if "X-RateLimit-Limit-day" in response.headers:
-                self.requests_per_day = response.headers["X-RateLimit-Limit-day"]
+                self.requests_per_day = int(response.headers["X-RateLimit-Limit-day"])
             if "X-RateLimit-Remaining-day" in response.headers:
-                self.requests_remaining = response.headers["X-RateLimit-Remaining-day"]
+                self.requests_remaining = int(response.headers["X-RateLimit-Remaining-day"])
             if response.status != 200:
                 _LOGGER.warning("Invalid response from Airly API: %s",
                                 response.status)

--- a/airly/_private.py
+++ b/airly/_private.py
@@ -27,6 +27,8 @@ class _RequestsHandler:
             self.headers['Accept-Language'] = language
         self.base_url = base_url
         self.session = session
+        self.requests_per_day = None
+        self.requests_remaining = None
 
     async def get(self, request_path):
         url = self.base_url + request_path
@@ -38,6 +40,8 @@ class _RequestsHandler:
                 raise AirlyError(response.status, await response.text())
 
             data = await response.json()
+            self.requests_per_day = response.headers.get("X-RateLimit-Limit-day")
+            self.requests_remaining = response.headers.get("X-RateLimit-Remaining-day")
             _LOGGER.debug(json.dumps(data))
             return data
 

--- a/airly/_private.py
+++ b/airly/_private.py
@@ -34,11 +34,10 @@ class _RequestsHandler:
         url = self.base_url + request_path
         _LOGGER.debug("Sending request: " + url)
         async with self.session.get(url, headers=self.headers) as response:
-            if response.status in (200, 429):
-                if "X-RateLimit-Limit-day" in response.headers:
-                    self.requests_per_day = response.headers["X-RateLimit-Limit-day"]
-                if "X-RateLimit-Remaining-day" in response.headers:
-                    self.requests_remaining = response.headers["X-RateLimit-Remaining-day"]
+            if "X-RateLimit-Limit-day" in response.headers:
+                self.requests_per_day = response.headers["X-RateLimit-Limit-day"]
+            if "X-RateLimit-Remaining-day" in response.headers:
+                self.requests_remaining = response.headers["X-RateLimit-Remaining-day"]
             if response.status != 200:
                 _LOGGER.warning("Invalid response from Airly API: %s",
                                 response.status)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+aioresponses
+aiounittest

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
+-e .
 aioresponses
 aiounittest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -e .
+aioresponses
 aiounittest
-asyncmock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+-e .
 aiounittest
 asyncmock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
 -e .
-aioresponses
-aiounittest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
--e .
+aiounittest
+asyncmock

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     test_suite='tests',
+    tests_require=("aioresponses", "aiounittest"),
 )

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,4 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     test_suite='tests',
-    tests_require=("aioresponses", "aiounittest"),
 )

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,4 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     test_suite='tests',
-    tests_require=('aiounittest'),
 )

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     test_suite='tests',
+    tests_require=('aiounittest'),
 )

--- a/tests/test__private.py
+++ b/tests/test__private.py
@@ -28,8 +28,8 @@ class _DictToObjTestCase(TestCase):
         self.assertEqual(2, sut.key2)
 
 
-class HeadersTestCase(AsyncTestCase):
-    async def test_valid_headers(self):
+class RemainingRequestsTestCase(AsyncTestCase):
+    async def test_valid_remaining_requests_headers(self):
         with open("data/measurements_typical.json") as file:
             data = json.load(file)
         headers = {"X-RateLimit-Limit-day": "1000", "X-RateLimit-Remaining-day": "993"}
@@ -46,7 +46,7 @@ class HeadersTestCase(AsyncTestCase):
             assert airly.requests_per_day == 1000
             assert airly.requests_remaining == 993
 
-    async def test_invalid_headers(self):
+    async def test_invalid_remaining_requests_headers(self):
         with open("data/measurements_typical.json") as file:
             data = json.load(file)
         headers = {}

--- a/tests/test__private.py
+++ b/tests/test__private.py
@@ -1,8 +1,10 @@
 import json
 from unittest import TestCase
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import Mock
 
 from aiounittest import AsyncTestCase
+from asyncmock import AsyncMock
+
 from airly import Airly
 from airly._private import _DictToObj
 

--- a/tests/test__private.py
+++ b/tests/test__private.py
@@ -1,5 +1,13 @@
-from airly._private import _DictToObj
+import json
 from unittest import TestCase
+from unittest.mock import AsyncMock, Mock
+
+from aiounittest import AsyncTestCase
+from airly import Airly
+from airly._private import _DictToObj
+
+LATITUDE = 12
+LONGITUDE = 21
 
 class _DictToObjTestCase(TestCase):
     def test_init_with_iterable(self):
@@ -16,3 +24,39 @@ class _DictToObjTestCase(TestCase):
         self.assertEqual('value1', sut.key1)
         self.assertEqual(2, sut['key2'])
         self.assertEqual(2, sut.key2)
+
+
+class HeadersTestCase(AsyncTestCase):
+    async def test_valid_headers(self):
+        with open("data/measurements_typical.json") as file:
+            data = json.load(file)
+        headers = {"X-RateLimit-Limit-day": "1000", "X-RateLimit-Remaining-day": "993"}
+        with Mock(
+            get=AsyncMock(side_effect=data),
+            headers=Mock(side_effect=headers),
+            status=200,
+            __enter__=Mock(),
+            __exit__=Mock(),
+        ) as mock_session:
+            airly = Airly("abcdef", mock_session)
+            measurements = airly.create_measurements_session_point(LATITUDE, LONGITUDE)
+            await measurements.update()
+            assert airly.requests_per_day == 1000
+            assert airly.requests_remaining == 993
+
+    async def test_invalid_headers(self):
+        with open("data/measurements_typical.json") as file:
+            data = json.load(file)
+        headers = {}
+        with Mock(
+            get=AsyncMock(side_effect=data),
+            headers=Mock(side_effect=headers),
+            status=200,
+            __enter__=Mock(),
+            __exit__=Mock(),
+        ) as mock_session:
+            airly = Airly("abcdef", mock_session)
+            measurements = airly.create_measurements_session_point(LATITUDE, LONGITUDE)
+            await measurements.update()
+            assert airly.requests_per_day == None
+            assert airly.requests_remaining == None


### PR DESCRIPTION
For new API keys, 100 requests are allowed per day, and for old API keys - 1000. Adding the `requests_remaining` and `requests_per_day` properties will help in calculating the possible data update interval.